### PR TITLE
0.1.0-pre-alpha READY.FOR.RELEASE

### DIFF
--- a/n.READY.FOR.RELEASE
+++ b/n.READY.FOR.RELEASE
@@ -1,0 +1,7 @@
+0.1.0-pre-alpha READY.FOR.RELEASE
+
+last commit 1716e4121833e06046f68a14e14e6d2ffab95419
+
+Date:   Wed Jul 28 18:29:54 2021 +0000
+
+    define cpl() - WORKING BLINK preserial


### PR DESCRIPTION
Initial PR to create a release (0.1.0-pre-alpha).

Working blink-wait-serial - not much else.

All old files included - this repository never did have a release.